### PR TITLE
Fixes issue in withTimeout regarding error vs. warning output

### DIFF
--- a/R/withTimeout.R
+++ b/R/withTimeout.R
@@ -110,7 +110,8 @@ withTimeout <- function(expr, envir=parent.frame(), timeout, cpu=timeout, elapse
   }, error = function(ex) {
     msg <- ex$message;
     # Was it a timeout?
-    pattern <- gettext("reached elapsed time limit", domain="R")
+    pattern <- gettext("reached elapsed time limit", "reached CPU time limit", domain="R")
+    pattern <- paste(pattern, collapse = "|")
     if (regexpr(pattern, msg) != -1L) {
       ex <- TimeoutException(msg, cpu=cpu, elapsed=elapsed);
       if (onTimeout == "error") {

--- a/tests/withTimeout.R
+++ b/tests/withTimeout.R
@@ -14,6 +14,10 @@ foo <- function() {
   print("Tac")
 }
 
+fib <- function(n) {
+  if (n == 0 | n == 1) return(n)
+  return (fib(n - 1) + fib(n - 2))
+}
 
 # - - - - - - - - - - - - - - - - - - - - - - - - -
 # Evaluate code, if it takes too long, generate
@@ -24,6 +28,19 @@ tryCatch({
   res <- withTimeout({
     foo()
   }, timeout=1.08)
+}, TimeoutException=function(ex) {
+  cat("Timeout (", ex$message, "). Skipping.\n", sep="")
+})
+
+# - - - - - - - - - - - - - - - - - - - - - - - - -
+# Evaluate code, if it takes too much CPU time,
+# generate a TimeoutException error.
+# - - - - - - - - - - - - - - - - - - - - - - - - -
+res <- NULL
+tryCatch({
+  res <- withTimeout({
+    fib(30)
+  }, cpu=0.1, elapsed=Inf)
 }, TimeoutException=function(ex) {
   cat("Timeout (", ex$message, "). Skipping.\n", sep="")
 })
@@ -41,6 +58,18 @@ tryCatch({
   cat("Timeout warning (", ex$message, "). Skipping.\n", sep="")
 })
 
+# - - - - - - - - - - - - - - - - - - - - - - - - -
+# Evaluate code, if it takes too much CPU time,
+# generate a timeout warning.
+# - - - - - - - - - - - - - - - - - - - - - - - - -
+res <- NULL
+tryCatch({
+  res <- withTimeout({
+    fib(30)
+  }, cpu=0.1, elapsed=Inf, onTimeout="warning")
+}, warning=function(ex) {
+  cat("Timeout warning (", ex$message, "). Skipping.\n", sep="")
+})
 
 # - - - - - - - - - - - - - - - - - - - - - - - - -
 # Evaluate code, if it takes too long, generate


### PR DESCRIPTION
I ran into the problem that when `withTimeout` reaches CPU (as opposed to "elapsed") timeout it always results in an error message, even when `onTimeout="warning"` was specified. For example I was getting:

```
f <- function(x) {
  for (i in 1:x^x) {
    rep(x, 1000)
  }
  return("finished")
}

a = withTimeout(f(8), cpu = 1, elapsed = Inf, onTimeout = "warning")
## Error in f(8) : reached CPU time limit
```

The little modification introduced in this pull request seems to solve the problem.