### PR TITLE
Fix `pattern` encoding

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -58,3 +58,5 @@ Rplots.pdf$
 #----------------------------
 ^.ghi
 ^.issues
+^R\.utils\.Rproj$
+^\.Rproj\.user$

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ revdep/checks/*
 revdep/library/*
 .Rdump
 docs
+.Rproj.user

--- a/R/Sys.readlink2.R
+++ b/R/Sys.readlink2.R
@@ -53,6 +53,7 @@ Sys.readlink2 <- function(paths, what=c("asis", "corrected")) {
 
     # Search for symbolic file or directory links
     pattern <- sprintf(".*[ ]+<SYMLINK(|D)>[ ]+(%s)[ ]+\\[(.+)\\][ ]*$", path)
+    Encoding(pattern) <- "UTF-8" # https://github.com/HenrikBengtsson/R.cache/issues/52
     bfr <- grep(pattern, bfr, value=TRUE)
 
     # Not a symbolic link?


### PR DESCRIPTION
After investigation, I realized that the encoding was not properly kept.

```r
    pattern <- sprintf(".*[ ]+<SYMLINK(|D)>[ ]+(%s)[ ]+\\[(.+)\\][ ]*$", path)
Encoding(pattern)
#> "unknown"
```


This PR adds UTF-8 to the pattern. I wonder if this can lead to an error with non-standard paths?

Aims to fix https://github.com/HenrikBengtsson/R.cache/issues/52

I wonder if additional tests would be required or if this is generally safe?

I ddidn't add NEWS because the NEWS file was not up to date with the CRAN version on the develop branch.


R CMD CHECK seems to pass locally for me on Windows, FR locale, 4.3.2