### PR TITLE
Silence warning

### DIFF
--- a/R/Sys.readlink2.R
+++ b/R/Sys.readlink2.R
@@ -53,7 +53,9 @@ Sys.readlink2 <- function(paths, what=c("asis", "corrected")) {
 
     # Search for symbolic file or directory links
     pattern <- sprintf(".*[ ]+<SYMLINK(|D)>[ ]+(%s)[ ]+\\[(.+)\\][ ]*$", path)
-    bfr <- grep(pattern, bfr, value=TRUE)
+    # On R > 4.3, bfr encoding may be problematic in some locales
+    # https://github.com/HenrikBengtsson/R.utils/issues/152
+    bfr <- suppressWarnings(grep(pattern, bfr, value=TRUE))
 
     # Not a symbolic link?
     if (length(bfr) == 0L) return("")


### PR DESCRIPTION
Addresses #152 

Since this code has been around for a while and seems to have worked as expected all this time, I think it may be safe to just silence the warning? Although if some files have non-ascii names, it may be problematic, but it is never a good idea to do this.

Anyway a warning to users is not very useful, because there is nothing we can do. The underlying could only be fixed either in R.utils (fix encoding when reading the `shell()` command or use another way to list files), base R `shell()` could maybe correct the encoding? or the OS directly (i.e. Windows)